### PR TITLE
Change link for Artists Re:thinking The Blockchain to link with both print and PDF versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ All of the following artists are either dedicated crypto artists or have been kn
 ## Books and References
 
 - [An Artist’s Dictionary for the Blockchain](https://medium.com/xlnt-art/an-artists-dictionary-for-the-blockchain-ba097e59c26b)
-- [Artists Re:thinking the Blockchain](https://liverpooluniversitypress.co.uk/products/100826)
+- [Artists Re:thinking the Blockchain](http://torquetorque.net/publications/artists-rethinking-the-blockchain/) (Print and free PDF)
 
 ## Communities and Genres
 


### PR DESCRIPTION
This diff substitutes the "Artists Re:thinking The Blockchain" editors' site for the publisher's site. It still links to the publisher's site, but also has a link for a free (and legal) download of the PDF version of the book.